### PR TITLE
NullReferenceException fix for Earthmover

### DIFF
--- a/UltraVoice/Characters/Earthmover.cs
+++ b/UltraVoice/Characters/Earthmover.cs
@@ -104,6 +104,9 @@ namespace UltraVoice.Characters
             if (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name != "6e981b1865c649749a610aafc471e198")
                 return;
 
+            if (__instance.to == null || __instance.to.clip == null)
+                return;
+
             if (__instance.to.clip.name == "Centaur A-2")
             {
                 UltraVoicePlugin.Instance.StartCoroutine(BloodVent());


### PR DESCRIPTION
Added null checks for __instance.to and __instance.to.clip in EarthmoverBloodVentPatch before accessing the clip name, preventing a NullReferenceException that occurred when '(Crossfade) "StartFade"' was called

_The same null checks in the EarthmoverPlayerDetectedPatch_

Edit: Ok so as it turns out this only occurs when someone has USTManager and a pack that alters any type of sound in 7-4 for some reason but it fixes it either way